### PR TITLE
Add full support for null in enums, and inline scalar enums

### DIFF
--- a/generation/ast_test.go
+++ b/generation/ast_test.go
@@ -250,7 +250,8 @@ const myName: Name = "coder";`,
 } as const;
 export type Status = typeof Status[keyof typeof Status];`,
 		},
-		// Type enum expressions
+		// Type enum expressions.  Because this is a scalar enum comprising only
+		// basic Types this should return a disjunction string only.
 		{
 			Expr: []*Expr{
 				{
@@ -264,7 +265,7 @@ export type Status = typeof Status[keyof typeof Status];`,
 					},
 				},
 			},
-			Expected: `export type Status = string | boolean;`,
+			Expected: `string | boolean;`,
 		},
 		// Object enums
 		{

--- a/testdata/basic.cue
+++ b/testdata/basic.cue
@@ -1,5 +1,7 @@
 Status: "open" | "closed"
 
+StrFloat: string | float
+
 #Some: {
 	with: string
 	...
@@ -17,7 +19,10 @@ Status: "open" | "closed"
 		staticBool?:     true
 		enabled:         bool
 		numeric:         number
-		mixed:           string | int
+		typeenum:        string | int
+		nullable:        string | float | null
+		typeints:        string | 0
+		typestrs:        "oh" | "hai" | string
 		friends: [...{
 			id:   int
 			name: string

--- a/testdata/basic.ts
+++ b/testdata/basic.ts
@@ -4,6 +4,8 @@ export const Status = {
 } as const;
 export type Status = typeof Status[keyof typeof Status];
 
+export type StrFloat = string | number;
+
 export interface Some {
   with: string;
 };
@@ -15,7 +17,9 @@ export const Action = {
 } as const;
 export type Action = typeof Action[keyof typeof Action];
 
-export type Mixed = string | number;
+export type Typeints = string | 0;
+
+export type Typestrs = "oh" | "hai" | string;
 
 export const Heyy = {
   WHAT: "what",
@@ -35,7 +39,10 @@ export interface Event {
     staticBool?: true;
     enabled: boolean;
     numeric: number;
-    mixed: Mixed;
+    typeenum: string | number;
+    nullable: string | number | null;
+    typeints: Typeints;
+    typestrs: Typestrs;
     friends: Array<{
       id: number;
       name: string;


### PR DESCRIPTION
This PR adds support for enums with null values:

```cue
{
	foo: string | null
}
```

And it inlines enums in struct definitions if the enum contains only
types:

```cue
data: {
	// the key is always present, but may be null
	name: string | null
}
```

generates:

```typescript
export interface Data {
  name: string | null;
};
```