### PR TITLE
Always inline enum types

### DIFF
--- a/generation/ast.go
+++ b/generation/ast.go
@@ -353,11 +353,11 @@ type Enum struct {
 // `string | number`, or `string | null`
 func (e Enum) IsScalarType() bool {
 	for _, m := range e.Members {
-		if _, ok := m.(Type); !ok {
-			return false
+		if _, ok := m.(Type); ok {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // ScalarAST returns the disjunction AST for basic types.  This is used

--- a/testdata/basic.ts
+++ b/testdata/basic.ts
@@ -17,10 +17,6 @@ export const Action = {
 } as const;
 export type Action = typeof Action[keyof typeof Action];
 
-export type Typeints = string | 0;
-
-export type Typestrs = "oh" | "hai" | string;
-
 export const Heyy = {
   WHAT: "what",
   DO: "do",
@@ -41,8 +37,8 @@ export interface Event {
     numeric: number;
     typeenum: string | number;
     nullable: string | number | null;
-    typeints: Typeints;
-    typestrs: Typestrs;
+    typeints: string | 0;
+    typestrs: "oh" | "hai" | string;
     friends: Array<{
       id: number;
       name: string;


### PR DESCRIPTION
Builds on #1.

Previously, we only inline enums if all values are a type:

```cue
evt: {
	// null is treated as a type in TS
	foo: string | null
	bar: string | "baz"
}
```

This generated:

```typescript
export type Bar = string | "baz";

export interface Evt {
  foo: string | null;
  bar: Bar;
};
```

With this PR we now generate:

```typescript
export interface Evt {
  foo: string | null;
  bar: string | "baz";
};
```

Note that enums containing values are still pulled out into top level
consts:

```typescript
export const Category = {
  TECH: "tech",
  FINANCE: "finance",
  HR: "hr",
} as const;
export type Category = typeof Category[keyof typeof Category];
```