### PR TITLE
Title case enum names generated from struct names

### DIFF
--- a/generation/generation.go
+++ b/generation/generation.go
@@ -3,6 +3,7 @@ package generation
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -14,6 +15,8 @@ import (
 var (
 	ctxIndentLevel = "indent"
 	ctxPath        = "path"
+
+	nonAlphaRegexp = regexp.MustCompile("[^\\w]|_")
 )
 
 // MarshalString marshals a Cue string into a Typescript type string,
@@ -494,6 +497,8 @@ func withPath(ctx context.Context, path string) context.Context {
 }
 
 func formatLabel(label string) (string, error) {
+	label = titleCaseName(label)
+
 	if len(label) == 0 {
 		return "", fmt.Errorf("unable to generate typescript for unnamed type")
 	}
@@ -504,4 +509,10 @@ func formatLabel(label string) (string, error) {
 	}
 
 	return label, nil
+}
+
+func titleCaseName(name string) string {
+	name = nonAlphaRegexp.ReplaceAllString(name, " ")
+	name = strings.Title(name)
+	return strings.ReplaceAll(name, " ", "")
 }

--- a/testdata/basic.cue
+++ b/testdata/basic.cue
@@ -11,6 +11,7 @@ StrFloat: string | float
 	name: string
 	data: {
 		action:          "push" | "pull" | "rebase"
+		another_enum:    "pending" | "in_progress" | "done"
 		status:          Status
 		number:          uint & <=10
 		static:          "lol this is content"

--- a/testdata/basic.ts
+++ b/testdata/basic.ts
@@ -17,6 +17,13 @@ export const Action = {
 } as const;
 export type Action = typeof Action[keyof typeof Action];
 
+export const AnotherEnum = {
+  PENDING: "pending",
+  IN_PROGRESS: "in_progress",
+  DONE: "done",
+} as const;
+export type AnotherEnum = typeof AnotherEnum[keyof typeof AnotherEnum];
+
 export const Heyy = {
   WHAT: "what",
   DO: "do",
@@ -27,6 +34,7 @@ export interface Event {
   name: string;
   data: {
     action: Action;
+    another_enum: AnotherEnum;
     status: Status;
     number: number;
     static: "lol this is content";


### PR DESCRIPTION
Tidies our generated names:

```cue
evt: {
  some_enum: "a" | "b";
}
```

becomes:

```typescript
export const SomeEnum = {
  A: "a",
  B: "b",
};
export type SomeEnum = typeof SomeEnum[keyof typeof SomeEnum];
```

Previously the name was `Some_enum` which, uh, sucked.